### PR TITLE
fix(cli): parse --token globally and allow graceful TUI auth retry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"ship-cli/config"
+
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +18,25 @@ var rootCmd = &cobra.Command{
 	Use:   "ship",
 	Short: "SHIP Platform CLI",
 	Long:  `A command line interface for interacting with the SHIP Platform.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// If token is not provided via flag, try to load it from config
+		if token == "" {
+			cfg, err := config.LoadConfig()
+			if err == nil && cfg.Token != "" {
+				token = cfg.Token
+			}
+		} else {
+			// If token is provided via flag, save it to config for future use
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				cfg = &config.Config{}
+			}
+			if cfg.Token != token {
+				cfg.Token = token
+				_ = config.SaveConfig(cfg)
+			}
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"ship-cli/api"
-	"ship-cli/config"
 	"ship-cli/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,14 +16,7 @@ var tuiCmd = &cobra.Command{
 	Short: "Launch the interactive TUI",
 	Long:  `Launch the interactive Text User Interface (TUI) for SHIP Platform.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// If token is not provided via flag, try to load it from config
-		if token == "" {
-			cfg, err := config.LoadConfig()
-			if err == nil && cfg.Token != "" {
-				token = cfg.Token
-			}
-		}
-
+		// Token is already loaded by rootCmd.PersistentPreRun
 		client := api.NewClient(apiServer, token)
 		m := ui.NewModel(client)
 

--- a/ui/tui.go
+++ b/ui/tui.go
@@ -226,6 +226,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.logCancel != nil {
 					m.logCancel()
 				}
+				
+				// Add specific fallback for unauthorized errors to allow token re-entry
+				if m.state == stateError && strings.Contains(m.err.Error(), "401") {
+					cfg, err := config.LoadConfig()
+					if err == nil {
+						cfg.Token = ""
+						_ = config.SaveConfig(cfg)
+					}
+					m.client.Token = ""
+					m.state = stateInputToken
+					m.textInput.Placeholder = "ship_pat_..."
+					m.textInput.SetValue("")
+					m.textInput.EchoMode = textinput.EchoPassword
+					m.textInput.EchoCharacter = '•'
+					m.textInput.CharLimit = 100
+					m.textInput.Width = 50
+					m.textInput.Focus()
+					return m, textinput.Blink
+				}
+				
 				return m, tea.Quit
 			}
 			if m.state == stateViewLogs {


### PR DESCRIPTION
Fixes a bug where providing `--token` was ignored because the root command wasn't hydrating the config before the child commands ran. Also adds a fallback in the TUI to redirect the user to the token input screen when a 401 Unauthorized is returned.