### PR TITLE
feat(cli): scrollable logs TUI and logs command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Binaries
 /build/
 /ship
+/ship-cli
+/ship-darwin-amd64
+/ship-darwin-arm64
+/ship-linux-amd64
+/ship-linux-arm64
 *.exe
 *.exe~
 *.dll

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -6,27 +6,51 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
+	"ship-cli/api"
+	"ship-cli/ui"
+
 	"github.com/spf13/cobra"
+)
+
+var (
+	logsFollow bool
+	logsTail   int
+	logsTui    bool
 )
 
 var logsCmd = &cobra.Command{
 	Use:   "logs [APP_ID]",
 	Short: "Stream logs from a deployed application",
-	Long:  `Stream live logs from a pod running in the SHIP Platform.`,
-	Args:  cobra.ExactArgs(1),
+	Long: `Stream logs from the main container of an app running on the SHIP Platform.
+
+Uses GET /api/applications/{id}/logs/stream (Server-Sent Events). Use --follow=false to
+fetch available lines and exit. Use --tail=N to limit to the last N lines.
+
+Use --tui for a full-screen scrollable viewer (arrow keys, PgUp/PgDn, mouse wheel).`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		appID := args[0]
 
 		if token == "" {
-			log.Fatal("Error: --token is required")
+			log.Fatal("Error: --token is required (or set token in ~/.ship/config.json)")
 		}
 
-		// Handle graceful shutdown
+		if logsTui {
+			client := api.NewClient(strings.TrimSuffix(apiServer, "/"), token)
+			if err := ui.RunLogsTUI(client, appID, logsFollow, logsTail); err != nil {
+				fmt.Fprintf(os.Stderr, "logs TUI: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		go func() {
@@ -41,16 +65,31 @@ var logsCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(logsCmd)
+	logsCmd.Flags().BoolVar(&logsFollow, "follow", true, "Keep streaming new log lines until interrupted")
+	logsCmd.Flags().IntVar(&logsTail, "tail", 0, "Only include the last N lines (0 = server default / full history)")
+	logsCmd.Flags().BoolVarP(&logsTui, "tui", "t", false, "Open logs in a full-screen scrollable TUI")
 }
 
 func streamLogs(appID string) {
-	url := fmt.Sprintf("%s/api/applications/%s/logs/stream", apiServer, appID)
-	
-	req, err := http.NewRequest("GET", url, nil)
+	base := strings.TrimSuffix(apiServer, "/")
+	u, err := url.Parse(base + "/api/applications/" + url.PathEscape(appID) + "/logs/stream")
+	if err != nil {
+		log.Fatalf("Invalid log URL: %v", err)
+	}
+	q := u.Query()
+	if !logsFollow {
+		q.Set("follow", "false")
+	}
+	if logsTail > 0 {
+		q.Set("tail", strconv.Itoa(logsTail))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		log.Fatalf("Failed to create request: %v", err)
 	}
-	
+
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "text/event-stream")
 
@@ -66,26 +105,25 @@ func streamLogs(appID string) {
 		log.Fatalf("Error streaming logs: HTTP %d %s", resp.StatusCode, string(body))
 	}
 
-		reader := bufio.NewReader(resp.Body)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				if err == io.EOF {
-					fmt.Println("\nLog stream closed by server.")
-					return
-				}
-				log.Fatalf("Error reading log stream: %v", err)
-			}
-			
-			// Parse SSE format (data: ...)
-			if strings.HasPrefix(line, "data: ") {
-				content := strings.TrimPrefix(line, "data: ")
-				if content != "stream ended\n" {
-					fmt.Print(content)
-				}
-			} else if strings.HasPrefix(line, "event: done") {
-				// Stream ended successfully
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				fmt.Println("\nLog stream closed by server.")
 				return
 			}
+			log.Fatalf("Error reading log stream: %v", err)
 		}
+
+		if strings.HasPrefix(line, "data: ") {
+			content := strings.TrimPrefix(line, "data: ")
+			if strings.TrimSpace(content) == "stream ended" {
+				return
+			}
+			fmt.Print(content)
+		} else if strings.HasPrefix(line, "event: done") {
+			return
+		}
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,22 +19,29 @@ var rootCmd = &cobra.Command{
 	Short: "SHIP Platform CLI",
 	Long:  `A command line interface for interacting with the SHIP Platform.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			cfg = &config.Config{}
+		}
+
+		serverFlag := cmd.PersistentFlags().Lookup("server")
+		if !serverFlag.Changed && cfg.Server != "" {
+			apiServer = cfg.Server
+		}
+
 		// If token is not provided via flag, try to load it from config
 		if token == "" {
-			cfg, err := config.LoadConfig()
-			if err == nil && cfg.Token != "" {
+			if cfg.Token != "" {
 				token = cfg.Token
 			}
-		} else {
-			// If token is provided via flag, save it to config for future use
-			cfg, err := config.LoadConfig()
-			if err != nil {
-				cfg = &config.Config{}
-			}
-			if cfg.Token != token {
-				cfg.Token = token
-				_ = config.SaveConfig(cfg)
-			}
+		} else if cfg.Token != token {
+			cfg.Token = token
+			_ = config.SaveConfig(cfg)
+		}
+
+		if serverFlag.Changed && cfg.Server != apiServer {
+			cfg.Server = apiServer
+			_ = config.SaveConfig(cfg)
 		}
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Config struct {
-	Token string `json:"token"`
+	Token  string `json:"token"`
+	Server string `json:"server,omitempty"`
 }
 
 func getConfigPath() (string, error) {

--- a/ui/logs_tui.go
+++ b/ui/logs_tui.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"ship-cli/api"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const logsTuiMaxChunks = 5000
+
+var logsTuiHelpStyle = lipgloss.NewStyle().Foreground(colorGray)
+
+// RunLogsTUI streams application logs in a scrollable full-screen TUI (bubbletea + viewport).
+func RunLogsTUI(client *api.Client, appID string, follow bool, tail int) error {
+	m := newLogsTUIModel(client, appID, follow, tail)
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	_, err := p.Run()
+	return err
+}
+
+type logsTUIModel struct {
+	client   *api.Client
+	appID    string
+	follow   bool
+	tail     int
+	viewport viewport.Model
+	chunks   []string
+	logChan  chan string
+	cancel   context.CancelFunc
+	ready    bool
+}
+
+func newLogsTUIModel(client *api.Client, appID string, follow bool, tail int) *logsTUIModel {
+	vp := viewport.New(0, 0)
+	vp.MouseWheelEnabled = true
+	return &logsTUIModel{
+		client:   client,
+		appID:    appID,
+		follow:   follow,
+		tail:     tail,
+		viewport: vp,
+	}
+}
+
+func (m *logsTUIModel) Init() tea.Cmd {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.logChan = make(chan string)
+	startLogsStream(ctx, m.client, m.appID, m.follow, m.tail, m.logChan)
+	return waitForLogLine(m.logChan)
+}
+
+func (m *logsTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			if m.cancel != nil {
+				m.cancel()
+			}
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		frameX, frameY := docStyle.GetFrameSize()
+		headerLines := 3
+		m.viewport.Width = msg.Width - frameX - 2
+		if m.viewport.Width < 20 {
+			m.viewport.Width = 20
+		}
+		m.viewport.Height = msg.Height - frameY - headerLines
+		if m.viewport.Height < 5 {
+			m.viewport.Height = 5
+		}
+		m.ready = true
+		m.viewport.SetContent(strings.Join(m.chunks, ""))
+		m.viewport.GotoBottom()
+		return m, nil
+	case newLogLineMsg:
+		if msg.line == "" {
+			return m, nil
+		}
+		m.chunks = append(m.chunks, msg.line)
+		if len(m.chunks) > logsTuiMaxChunks {
+			m.chunks = m.chunks[len(m.chunks)-logsTuiMaxChunks:]
+		}
+		if m.ready {
+			m.viewport.SetContent(strings.Join(m.chunks, ""))
+			m.viewport.GotoBottom()
+		}
+		return m, waitForLogLine(m.logChan)
+	}
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+func (m *logsTUIModel) View() string {
+	title := titleStyle.Render(fmt.Sprintf("Logs · %s", m.appID))
+	if !m.follow {
+		title += " " + lipgloss.NewStyle().Foreground(colorGray).Render("(snapshot)")
+	}
+	body := m.viewport.View()
+	help := logsTuiHelpStyle.Render("↑/↓/PgUp/PgDn scroll · mouse wheel · q/esc quit")
+	return docStyle.Render(title + "\n\n" + body + "\n" + help)
+}

--- a/ui/tui.go
+++ b/ui/tui.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -413,7 +414,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.logCancel = cancel
 					m.logChan = make(chan string)
 					
-					startLogsStream(ctx, m.client, m.selectedApp.ID, m.logChan)
+					startLogsStream(ctx, m.client, m.selectedApp.ID, true, 0, m.logChan)
 					return m, waitForLogLine(m.logChan)
 				}
 			}
@@ -535,10 +536,26 @@ type portForwardStartedMsg struct{
 	session *PortForwardSession
 }
 
-func startLogsStream(ctx context.Context, client *api.Client, appID string, logChan chan string) {
+func startLogsStream(ctx context.Context, client *api.Client, appID string, follow bool, tail int, logChan chan string) {
 	go func() {
-		url := fmt.Sprintf("%s/api/applications/%s/logs/stream", strings.TrimSuffix(client.BaseURL, "/"), appID)
-		req, err := http.NewRequest("GET", url, nil)
+		defer close(logChan)
+
+		base := strings.TrimSuffix(client.BaseURL, "/")
+		u, err := url.Parse(base + "/api/applications/" + url.PathEscape(appID) + "/logs/stream")
+		if err != nil {
+			logChan <- fmt.Sprintf("Error: invalid log URL: %v\n", err)
+			return
+		}
+		q := u.Query()
+		if !follow {
+			q.Set("follow", "false")
+		}
+		if tail > 0 {
+			q.Set("tail", strconv.Itoa(tail))
+		}
+		u.RawQuery = q.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 		if err != nil {
 			logChan <- fmt.Sprintf("Error creating request: %v\n", err)
 			return
@@ -554,6 +571,12 @@ func startLogsStream(ctx context.Context, client *api.Client, appID string, logC
 			return
 		}
 		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			logChan <- fmt.Sprintf("Error: HTTP %d %s\n", resp.StatusCode, string(body))
+			return
+		}
 
 		reader := bufio.NewReader(resp.Body)
 		for {


### PR DESCRIPTION
## Summary
Adds a scrollable logs TUI and wires the `logs` command.

## Changes
- Scrollable logs TUI (`ui/logs_tui.go`, `ui/tui.go`)
- `logs` command wiring (`cmd/logs.go`, `cmd/root.go`)
- Config updates (`config/config.go`)
- `.gitignore` for local cross-compiled binaries

Ref: commit `0cd7b83`.

Made with [Cursor](https://cursor.com)