### PR TITLE
P0-005: encode project-scoped application requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -64,7 +66,15 @@ func (c *Client) GetProjects() ([]Project, error) {
 }
 
 func (c *Client) GetApplications(projectID string) ([]Application, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/applications?projectId=%s", c.BaseURL, projectID), nil)
+	endpoint, err := url.Parse(strings.TrimRight(c.BaseURL, "/") + "/api/applications")
+	if err != nil {
+		return nil, err
+	}
+	query := endpoint.Query()
+	query.Set("projectId", projectID)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequest("GET", endpoint.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_GetApplicationsBuildsScopedRequest(t *testing.T) {
+	t.Parallel()
+	const projectID = "project/id with space"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/applications" {
+			t.Errorf("path = %q, want /api/applications", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("projectId"); got != projectID {
+			t.Errorf("projectId = %q, want %q", got, projectID)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want Bearer test-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"app-1","name":"Demo","projectId":"project/id with space"}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL+"/", "test-token")
+	apps, err := client.GetApplications(projectID)
+	if err != nil {
+		t.Fatalf("GetApplications: %v", err)
+	}
+	if len(apps) != 1 || apps[0].ID != "app-1" || apps[0].ProjectID != projectID {
+		t.Fatalf("applications = %#v, want one scoped application", apps)
+	}
+}
+
+func TestClient_GetApplicationsRejectsNonOKResponse(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, "test-token")
+	if _, err := client.GetApplications("missing-project"); err == nil {
+		t.Fatal("GetApplications should reject a non-200 response")
+	}
+}


### PR DESCRIPTION
## Outcome

Build the application list URL with net/url so the selected projectId is encoded safely while preserving authorization and response behavior.

## Verification

- complete CLI suite, 20 runs: pass
- complete race suite: pass
- go vet: pass
- request path/query/header/response and non-200 cases covered
- Gitleaks and diff checks: pass

No CLI command or flag changes. Rollback is a commit revert.