### PR TITLE
P1-019: improve installer progress and prepare v1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Install the CLI to `/usr/local/bin/ship` with a single command (Linux/macOS):
 ```bash
 curl -sL https://console.ship-platform.com/install.sh | bash
 ```
+
+The installer displays each stage and animates the binary download in an
+interactive terminal, so slow connections still show visible activity.
+
 *(Windows users: download the `.exe` from [Releases](https://github.com/SHIP-platform/ship-cli/releases)).*
 
 ### 2. Launch & Authenticate
@@ -55,7 +59,7 @@ ship port-forward <APP_ID> --local-port 5432 --target-port 5432
 
 ## 🛠️ Development
 
-Requires Go 1.22+.
+Requires Go 1.24.2+ (matching `go.mod`).
 
 ```bash
 git clone https://github.com/SHIP-platform/ship-cli.git

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Current version of the CLI. This should be updated when bumping versions
-const CurrentVersion = "1.0.5"
+const CurrentVersion = "1.0.6"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -29,7 +29,7 @@ func init() {
 
 func checkUpdate() {
 	fmt.Println("\nChecking for updates...")
-	
+
 	resp, err := http.Get("https://api.github.com/repos/SHIP-platform/ship-cli/releases/latest")
 	if err != nil {
 		fmt.Println("Failed to check for updates.")
@@ -45,7 +45,7 @@ func checkUpdate() {
 	var result struct {
 		TagName string `json:"tag_name"`
 	}
-	
+
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		fmt.Println("Failed to parse release info.")
 		return
@@ -58,11 +58,11 @@ func checkUpdate() {
 
 	if latestVersion != CurrentVersion {
 		fmt.Printf("🚀 A new version of SHIP CLI is available! (v%s -> v%s)\n", CurrentVersion, latestVersion)
-		
+
 		fmt.Print("Would you like to update now? [Y/n]: ")
 		var response string
 		fmt.Scanln(&response)
-		
+
 		if response == "" || response == "y" || response == "Y" {
 			fmt.Println("Updating...")
 			updateCmd := exec.Command("bash", "-c", "curl -sL https://console.ship-platform.com/install.sh | bash")

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -37,38 +37,24 @@ You can create a new route in your `ship-api` (e.g., `GET /api/cli/download/{os}
 
 ## 3. Installation Scripts
 
-To make installation seamless for users, you can provide a simple `curl` script that automatically detects their OS and downloads the correct binary.
+The supported installer is [`scripts/install.sh`](../scripts/install.sh). The
+Console serves that file at `https://console.ship-platform.com/install.sh`, and
+the script resolves the latest GitHub Release asset for the detected Linux or
+macOS architecture.
 
-Create a file named `install.sh` and host it on your console (e.g., `https://console.ship-platform.com/install.sh`):
+The installer must keep these user-facing guarantees:
+
+- display platform detection, download, and installation stages;
+- animate the download only when stdout is an interactive terminal;
+- keep redirected/CI output line-based and free of terminal control noise;
+- fail on HTTP errors and remove partial temporary files;
+- fall back to an existing `~/.local/bin` or `~/bin` when sudo is unavailable.
+
+Verify installer changes without network or system-directory writes:
 
 ```bash
-#!/bin/bash
-set -e
-
-echo "Downloading SHIP CLI..."
-
-OS="$(uname -s | tr A-Z a-z)"
-ARCH="$(uname -m)"
-
-if [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-    ARCH="arm64"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
-
-# Replace this URL with wherever you decide to host the binaries
-DOWNLOAD_URL="https://github.com/your-org/ship-cli/releases/latest/download/ship-${OS}-${ARCH}"
-
-curl -sL "$DOWNLOAD_URL" -o ship
-chmod +x ship
-
-echo "Installing to /usr/local/bin (requires sudo)..."
-sudo mv ship /usr/local/bin/ship
-
-echo "Installation complete! Run 'ship tui' to get started."
+bash -n scripts/install.sh scripts/install_test.sh
+bash scripts/install_test.sh
 ```
 
 Users can then install your CLI with a single command:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,68 +1,161 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# SHIP CLI Installation Script
+readonly RELEASE_BASE_URL="https://github.com/SHIP-platform/ship-cli/releases/latest/download"
 
-echo "========================================"
-echo "      Downloading SHIP CLI...           "
-echo "========================================"
+TMP_FILE=""
+DOWNLOAD_PID=""
 
-# Detect OS
-OS="$(uname -s | tr A-Z a-z)"
-# Detect Architecture
-ARCH="$(uname -m)"
+cleanup() {
+    if [[ -n "$DOWNLOAD_PID" ]] && kill -0 "$DOWNLOAD_PID" 2>/dev/null; then
+        kill "$DOWNLOAD_PID" 2>/dev/null || true
+        wait "$DOWNLOAD_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$TMP_FILE" ]]; then
+        rm -f "$TMP_FILE"
+    fi
+}
 
-if [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-    ARCH="arm64"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
+interrupt() {
+    printf '\nInstallation interrupted.\n' >&2
+    exit 130
+}
 
-# Define the binary name based on OS and ARCH
-BINARY_NAME="ship-${OS}-${ARCH}"
+trap cleanup EXIT
+trap interrupt HUP INT TERM
 
-# Fetch the latest release from GitHub
-DOWNLOAD_URL="https://github.com/SHIP-platform/ship-cli/releases/latest/download/${BINARY_NAME}"
+detect_platform() {
+    local os
+    local arch
 
-echo "Detected OS: $OS"
-echo "Detected Architecture: $ARCH"
-echo "Fetching from: $DOWNLOAD_URL"
-echo ""
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
 
-# Download the binary to a temporary file first
-TMP_FILE=$(mktemp)
-curl -sL "$DOWNLOAD_URL" -o "$TMP_FILE"
+    case "$os" in
+        linux | darwin) ;;
+        *)
+            printf 'Unsupported operating system: %s\n' "$os" >&2
+            return 1
+            ;;
+    esac
 
-# Make it executable
-chmod +x "$TMP_FILE"
+    case "$arch" in
+        x86_64 | amd64) arch="amd64" ;;
+        aarch64 | arm64) arch="arm64" ;;
+        *)
+            printf 'Unsupported architecture: %s\n' "$arch" >&2
+            return 1
+            ;;
+    esac
 
-echo ""
-# Check if /usr/local/bin exists and is in PATH, fallback to ~/.local/bin or ~/bin
-INSTALL_DIR="/usr/local/bin"
+    OS="$os"
+    ARCH="$arch"
+    BINARY_NAME="ship-${OS}-${ARCH}"
+    DOWNLOAD_URL="${RELEASE_BASE_URL}/${BINARY_NAME}"
+}
 
-# If the user doesn't have sudo rights and isn't root, we might need to install to a local bin
-if [ "$EUID" -ne 0 ] && ! sudo -v >/dev/null 2>&1; then
-    if [ -d "$HOME/.local/bin" ]; then
+download_binary() {
+    local curl_status
+    local frame=0
+    local frames='|/-\'
+
+    if [[ -t 1 && "${TERM:-dumb}" != "dumb" ]]; then
+        curl --fail --location --silent --show-error "$DOWNLOAD_URL" -o "$TMP_FILE" &
+        DOWNLOAD_PID=$!
+
+        while kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
+            printf '\r\033[2K[2/3] Downloading %s %s' \
+                "$BINARY_NAME" "${frames:frame++%${#frames}:1}"
+            sleep 0.12
+        done
+
+        if wait "$DOWNLOAD_PID"; then
+            curl_status=0
+        else
+            curl_status=$?
+        fi
+        DOWNLOAD_PID=""
+
+        if [[ "$curl_status" -ne 0 ]]; then
+            printf '\r\033[2K[2/3] Download failed for %s.\n' "$BINARY_NAME" >&2
+            return "$curl_status"
+        fi
+        printf '\r\033[2K[2/3] Downloaded %s.\n' "$BINARY_NAME"
+    else
+        printf '[2/3] Downloading %s...\n' "$BINARY_NAME"
+        if ! curl --fail --location --silent --show-error "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+            printf '[2/3] Download failed for %s.\n' "$BINARY_NAME" >&2
+            return 1
+        fi
+        printf '[2/3] Downloaded %s.\n' "$BINARY_NAME"
+    fi
+
+    if [[ ! -s "$TMP_FILE" ]]; then
+        printf 'Downloaded file is empty.\n' >&2
+        return 1
+    fi
+    chmod +x "$TMP_FILE"
+}
+
+resolve_install_dir() {
+    INSTALL_DIR="/usr/local/bin"
+    USE_SUDO=false
+
+    if [[ "$EUID" -eq 0 ]]; then
+        return
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+        printf '[3/3] Checking install permission (sudo may prompt)...\n'
+        if sudo -v; then
+            USE_SUDO=true
+            return
+        fi
+    fi
+
+    if [[ -d "$HOME/.local/bin" ]]; then
         INSTALL_DIR="$HOME/.local/bin"
-    elif [ -d "$HOME/bin" ]; then
+    elif [[ -d "$HOME/bin" ]]; then
         INSTALL_DIR="$HOME/bin"
     else
-        echo "Requires sudo privileges to install to /usr/local/bin. Please run with sudo."
-        exit 1
+        printf 'Cannot write to /usr/local/bin and no user bin directory exists.\n' >&2
+        printf 'Create %s/.local/bin or run this installer with sudo access.\n' "$HOME" >&2
+        return 1
     fi
-    echo "Installing locally to $INSTALL_DIR..."
-    mv "$TMP_FILE" "$INSTALL_DIR/ship"
-else
-    echo "Installing to $INSTALL_DIR (this may require your password)..."
-    # Use -f to forcefully overwrite existing binary
-    sudo mv -f "$TMP_FILE" "$INSTALL_DIR/ship"
-fi
+}
 
-echo ""
-echo "========================================"
-echo "  Installation complete! 🚀             "
-echo "========================================"
-echo "Run 'ship --help' to get started."
+install_binary() {
+    printf '[3/3] Installing to %s/ship...\n' "$INSTALL_DIR"
+    if [[ "$USE_SUDO" == true ]]; then
+        sudo mv -f "$TMP_FILE" "$INSTALL_DIR/ship"
+    else
+        mv -f "$TMP_FILE" "$INSTALL_DIR/ship"
+    fi
+    TMP_FILE=""
+}
+
+main() {
+    printf '%s\n' '========================================'
+    printf '%s\n' '          SHIP CLI Installer            '
+    printf '%s\n' '========================================'
+
+    if ! command -v curl >/dev/null 2>&1; then
+        printf 'curl is required to install SHIP CLI.\n' >&2
+        return 1
+    fi
+
+    printf '[1/3] Detecting platform...\n'
+    detect_platform
+    printf '[1/3] Platform: %s/%s.\n' "$OS" "$ARCH"
+
+    TMP_FILE="$(mktemp)"
+    download_binary
+    resolve_install_dir
+    install_binary
+
+    printf '%s\n' '========================================'
+    printf '%s\n' '  Installation complete! Run: ship tui '
+    printf '%s\n' '========================================'
+}
+
+main "$@"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly INSTALLER="$ROOT_DIR/scripts/install.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+assert_contains() {
+    local output="$1"
+    local expected="$2"
+    [[ "$output" == *"$expected"* ]] || fail "expected output to contain: $expected"
+}
+
+create_mocks() {
+    local mock_dir="$1"
+    mkdir -p "$mock_dir"
+
+    cat >"$mock_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -s) printf 'Linux\n' ;;
+    -m) printf 'x86_64\n' ;;
+    *) exit 1 ;;
+esac
+EOF
+
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -o | --output)
+            output="$2"
+            shift 2
+            ;;
+        *) shift ;;
+    esac
+done
+sleep "${MOCK_CURL_DELAY:-0}"
+if [[ "${MOCK_CURL_FAIL:-0}" == "1" ]]; then
+    printf 'curl: mocked download failure\n' >&2
+    exit 22
+fi
+printf '#!/usr/bin/env sh\nprintf "SHIP CLI mock\\n"\n' >"$output"
+EOF
+
+    cat >"$mock_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+    cat >"$mock_dir/mktemp" <<'EOF'
+#!/usr/bin/env bash
+: >"$MOCK_TMP_FILE"
+printf '%s\n' "$MOCK_TMP_FILE"
+EOF
+
+    chmod +x "$mock_dir/uname" "$mock_dir/curl" "$mock_dir/sudo" "$mock_dir/mktemp"
+}
+
+run_non_tty_success() {
+    local case_dir="$TEST_ROOT/non-tty"
+    local mock_dir="$case_dir/mocks"
+    local home_dir="$case_dir/home"
+    local output
+    mkdir -p "$home_dir/.local/bin"
+    create_mocks "$mock_dir"
+
+    output="$(env \
+        PATH="$mock_dir:$PATH" \
+        HOME="$home_dir" \
+        MOCK_TMP_FILE="$case_dir/download.tmp" \
+        bash "$INSTALLER" 2>&1)"
+
+    assert_contains "$output" "[1/3] Platform: linux/amd64."
+    assert_contains "$output" "[2/3] Downloading ship-linux-amd64..."
+    assert_contains "$output" "[2/3] Downloaded ship-linux-amd64."
+    assert_contains "$output" "[3/3] Checking install permission (sudo may prompt)..."
+    assert_contains "$output" "[3/3] Installing to $home_dir/.local/bin/ship..."
+    assert_contains "$output" "Installation complete! Run: ship tui"
+    [[ "$output" != *$'\r'* ]] || fail "non-TTY output contains carriage returns"
+    [[ -x "$home_dir/.local/bin/ship" ]] || fail "installer did not create an executable"
+    [[ ! -e "$case_dir/download.tmp" ]] || fail "temporary download was not moved or cleaned"
+}
+
+run_tty_success() {
+    local case_dir="$TEST_ROOT/tty"
+    local mock_dir="$case_dir/mocks"
+    local home_dir="$case_dir/home"
+    local spinner_count
+    local transcript="$case_dir/transcript.log"
+    mkdir -p "$home_dir/.local/bin"
+    create_mocks "$mock_dir"
+
+    if script --version 2>&1 | grep -qi 'util-linux'; then
+        script -q -e -c \
+            "env PATH='$mock_dir:$PATH' HOME='$home_dir' TERM=xterm MOCK_CURL_DELAY=0.35 MOCK_TMP_FILE='$case_dir/download.tmp' bash '$INSTALLER'" \
+            "$transcript" >/dev/null
+    else
+        script -q "$transcript" env \
+            PATH="$mock_dir:$PATH" \
+            HOME="$home_dir" \
+            TERM=xterm \
+            MOCK_CURL_DELAY=0.35 \
+            MOCK_TMP_FILE="$case_dir/download.tmp" \
+            bash "$INSTALLER" >/dev/null
+    fi
+
+    grep -Fq "[2/3] Downloading ship-linux-amd64" "$transcript" || \
+        fail "TTY output did not show the spinner stage"
+    spinner_count="$(tr '\r' '\n' <"$transcript" | grep -Fc '[2/3] Downloading ship-linux-amd64')"
+    [[ "$spinner_count" -ge 2 ]] || fail "TTY output did not render multiple spinner frames"
+    grep -Fq "[2/3] Downloaded ship-linux-amd64." "$transcript" || \
+        fail "TTY output did not show download completion"
+    grep -q $'\r' "$transcript" || fail "TTY output did not animate with carriage returns"
+    [[ -x "$home_dir/.local/bin/ship" ]] || fail "TTY installer did not create an executable"
+}
+
+run_download_failure() {
+    local case_dir="$TEST_ROOT/failure"
+    local mock_dir="$case_dir/mocks"
+    local home_dir="$case_dir/home"
+    local output
+    mkdir -p "$home_dir/.local/bin"
+    create_mocks "$mock_dir"
+
+    if output="$(env \
+        PATH="$mock_dir:$PATH" \
+        HOME="$home_dir" \
+        MOCK_CURL_FAIL=1 \
+        MOCK_TMP_FILE="$case_dir/download.tmp" \
+        bash "$INSTALLER" 2>&1)"; then
+        fail "installer succeeded after a mocked download failure"
+    fi
+
+    assert_contains "$output" "Download failed for ship-linux-amd64."
+    [[ ! -e "$home_dir/.local/bin/ship" ]] || fail "failed download installed a binary"
+    [[ ! -e "$case_dir/download.tmp" ]] || fail "failed download left a temporary file"
+}
+
+run_non_tty_success
+run_tty_success
+run_download_failure
+printf 'PASS: installer progress and failure behavior\n'


### PR DESCRIPTION
## Summary
- show three explicit installer stages and a live TTY spinner during binary download
- keep redirected output line-based; fail on HTTP errors and clean partial files
- add isolated installer tests and bump the CLI version to 1.0.6
- synchronize README and distribution guidance

## Verification
- `bash -n scripts/install.sh scripts/install_test.sh`
- `bash scripts/install_test.sh`
- `go test -count=1 ./...`
- `go test -count=1 -race ./...`
- `go vet ./...`
- cross-compiled Linux amd64/arm64, macOS amd64/arm64, and Windows amd64
- `git diff --check`

## Risk and rollback
The public install command and release asset names are unchanged. Animation is TTY-gated. Roll back by reverting commit `f1277d1`; no data or config migration is involved.

Release `v1.0.6` will be built and published only after this PR merges.

Task: P1-019