### PR TITLE
P0-004: simplify port-forward configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <p><strong>The official command-line interface for the SHIP Platform.</strong></p>
 </div>
 
-The `ship` CLI is an interactive terminal tool to manage projects, view applications, and securely tunnel traffic into internal Kubernetes pods.
+The `ship` CLI is an interactive terminal tool to manage projects, view applications, and securely tunnel traffic into application services.
 
 ## 🚀 Quick Start
 
@@ -37,7 +37,8 @@ Use the CLI to securely connect to internal databases (PostgreSQL, MongoDB, etc.
 
 1. Use `↑` / `↓` and `Enter` to select a **Project** ➔ **Application**.
 2. Select **Start Port Forward**.
-3. Enter a **Local Port** (e.g., `5432`) and a **Target Port** (e.g., `5432`).
+3. Enter a **Local Port** (for example, `5432`). SHIP automatically uses the
+   application's declared runtime port.
 
 A ⚡ icon will appear next to the app, indicating the tunnel is running in the background. You can now connect using your local tools:
 ```bash
@@ -52,7 +53,16 @@ psql -h localhost -p 5432 -U postgres
 ### Direct Command
 Bypass the UI for scripts:
 ```bash
-ship port-forward <APP_ID> --local-port 5432 --target-port 5432
+ship port-forward <APP_ID> --local-port 5432
+```
+
+REST commands use `--server`. Port-forward uses the independent
+`--websocket-server` flag, which defaults to the SHIP Console WebSocket edge.
+Set it when connecting through a local or self-hosted edge:
+
+```bash
+ship port-forward <APP_ID> --local-port 5432 \
+  --websocket-server ws://127.0.0.1:3000
 ```
 
 ---

--- a/api/client.go
+++ b/api/client.go
@@ -10,15 +10,17 @@ import (
 )
 
 type Client struct {
-	BaseURL    string
-	Token      string
-	HTTPClient *http.Client
+	BaseURL       string
+	WebSocketBase string
+	Token         string
+	HTTPClient    *http.Client
 }
 
 func NewClient(baseURL, token string) *Client {
 	return &Client{
-		BaseURL: baseURL,
-		Token:   token,
+		BaseURL:       baseURL,
+		WebSocketBase: DefaultWebSocketBase,
+		Token:         token,
 		HTTPClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const DefaultWebSocketBase = "wss://console.ship-platform.com"
+
+// BuildPortForwardURL constructs the public port-forward WebSocket endpoint.
+// The WebSocket origin is intentionally independent from the REST API origin.
+func BuildPortForwardURL(baseURL, applicationID, token string) (string, error) {
+	if applicationID == "" {
+		return "", fmt.Errorf("application ID is required")
+	}
+
+	endpoint, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse WebSocket server URL: %w", err)
+	}
+	if endpoint.Scheme != "ws" && endpoint.Scheme != "wss" {
+		return "", fmt.Errorf("WebSocket server URL must use ws or wss")
+	}
+	if endpoint.Host == "" {
+		return "", fmt.Errorf("WebSocket server URL must include a host")
+	}
+	if endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return "", fmt.Errorf("WebSocket server URL must not include user info, query, or fragment")
+	}
+
+	basePath := strings.TrimRight(endpoint.Path, "/")
+	baseRawPath := strings.TrimRight(endpoint.EscapedPath(), "/")
+	endpoint.Path = basePath + "/ws/portforward/" + applicationID
+	endpoint.RawPath = baseRawPath + "/ws/portforward/" + url.PathEscape(applicationID)
+	query := endpoint.Query()
+	query.Set("token", token)
+	endpoint.RawQuery = query.Encode()
+
+	return endpoint.String(), nil
+}

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuildPortForwardURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		base    string
+		appID   string
+		token   string
+		wantURL string
+	}{
+		{
+			name:    "production default",
+			base:    DefaultWebSocketBase,
+			appID:   "app-123",
+			token:   "ship_pat_token",
+			wantURL: "wss://console.ship-platform.com/ws/portforward/app-123?token=ship_pat_token",
+		},
+		{
+			name:    "custom base and trailing slash",
+			base:    "ws://127.0.0.1:3000/edge/",
+			appID:   "app-123",
+			token:   "token",
+			wantURL: "ws://127.0.0.1:3000/edge/ws/portforward/app-123?token=token",
+		},
+		{
+			name:    "encoded path and query values",
+			base:    "wss://example.test",
+			appID:   "app/id with space",
+			token:   "token&scope=admin",
+			wantURL: "wss://example.test/ws/portforward/app%2Fid%20with%20space?token=token%26scope%3Dadmin",
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := BuildPortForwardURL(testCase.base, testCase.appID, testCase.token)
+			if err != nil {
+				t.Fatalf("BuildPortForwardURL: %v", err)
+			}
+			if got != testCase.wantURL {
+				t.Fatalf("URL = %q, want %q", got, testCase.wantURL)
+			}
+			parsed, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("parse result: %v", err)
+			}
+			if parsed.Query().Get("token") != testCase.token {
+				t.Fatalf("decoded token = %q, want %q", parsed.Query().Get("token"), testCase.token)
+			}
+		})
+	}
+}
+
+func TestBuildPortForwardURLRejectsInvalidBase(t *testing.T) {
+	t.Parallel()
+
+	for _, base := range []string{
+		"https://console.ship-platform.com",
+		"wss:///missing-host",
+		"wss://user@example.test",
+		"wss://example.test?source=test",
+		"wss://example.test#fragment",
+	} {
+		base := base
+		t.Run(strings.ReplaceAll(base, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+			if _, err := BuildPortForwardURL(base, "app-123", "token"); err == nil {
+				t.Fatalf("BuildPortForwardURL(%q) should fail", base)
+			}
+		})
+	}
+}
+
+func TestBuildPortForwardURLRequiresApplicationID(t *testing.T) {
+	t.Parallel()
+	if _, err := BuildPortForwardURL(DefaultWebSocketBase, "", "token"); err == nil {
+		t.Fatal("BuildPortForwardURL should require an application ID")
+	}
+}

--- a/cmd/portforward.go
+++ b/cmd/portforward.go
@@ -9,25 +9,28 @@ import (
 	"os/signal"
 	"syscall"
 
+	"ship-cli/api"
+
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 )
 
-var (
-	localPort  int
-	targetPort int
-)
+var localPort int
 
 var portForwardCmd = &cobra.Command{
 	Use:   "port-forward [APP_ID]",
-	Short: "Forward one or more local ports to a pod",
-	Long:  `Forward one or more local ports to a pod running in the SHIP Platform.`,
+	Short: "Forward a local port to an application service",
+	Long:  `Forward a local port to an application service running on the SHIP Platform.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		appID := args[0]
 
 		if token == "" {
 			log.Fatal("Error: --token is required")
+		}
+		wsURL, err := api.BuildPortForwardURL(websocketServer, appID, token)
+		if err != nil {
+			log.Fatalf("Invalid WebSocket server URL: %v", err)
 		}
 
 		listenAddr := fmt.Sprintf("localhost:%d", localPort)
@@ -37,8 +40,7 @@ var portForwardCmd = &cobra.Command{
 		}
 		defer l.Close()
 
-		fmt.Printf("Forwarding from 127.0.0.1:%d -> %d\n", localPort, targetPort)
-		fmt.Printf("Forwarding from [::1]:%d -> %d\n", localPort, targetPort)
+		fmt.Printf("Forwarding localhost:%d -> application service\n", localPort)
 
 		// Handle graceful shutdown
 		c := make(chan os.Signal, 1)
@@ -57,7 +59,7 @@ var portForwardCmd = &cobra.Command{
 				return
 			}
 			fmt.Println("Handling connection for", localPort)
-			go handleConnection(conn, appID)
+			go handleConnection(conn, wsURL)
 		}
 	},
 }
@@ -66,14 +68,11 @@ func init() {
 	rootCmd.AddCommand(portForwardCmd)
 
 	portForwardCmd.Flags().IntVarP(&localPort, "local-port", "l", 8080, "Local port to listen on")
-	portForwardCmd.Flags().IntVarP(&targetPort, "target-port", "t", 80, "Target port on the pod")
 	portForwardCmd.MarkFlagRequired("token")
 }
 
-func handleConnection(localConn net.Conn, appID string) {
+func handleConnection(localConn net.Conn, wsURL string) {
 	defer localConn.Close()
-
-	wsURL := fmt.Sprintf("%s/ws/portforward/%s?port=%d&token=%s", apiServer, appID, targetPort, token)
 
 	// Connect to WebSocket
 	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)

--- a/cmd/portforward_test.go
+++ b/cmd/portforward_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+
+	"ship-cli/api"
+)
+
+func TestPortForwardCommandUsesLocalPortOnly(t *testing.T) {
+	if portForwardCmd.Flags().Lookup("local-port") == nil {
+		t.Fatal("port-forward must expose --local-port")
+	}
+	if portForwardCmd.Flags().Lookup("target-port") != nil {
+		t.Fatal("port-forward must not expose --target-port")
+	}
+
+	flag := rootCmd.PersistentFlags().Lookup("websocket-server")
+	if flag == nil {
+		t.Fatal("root command must expose --websocket-server")
+	}
+	if flag.DefValue != api.DefaultWebSocketBase {
+		t.Fatalf("--websocket-server default = %q, want %q", flag.DefValue, api.DefaultWebSocketBase)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"os"
 
+	"ship-cli/api"
 	"ship-cli/config"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	token     string
-	apiServer string
+	token           string
+	apiServer       string
+	websocketServer string
 )
 
 var rootCmd = &cobra.Command{
@@ -50,4 +52,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&token, "token", "", "Personal Access Token for authentication")
 	rootCmd.PersistentFlags().StringVar(&apiServer, "server", "https://api.ship-platform.com", "API Server URL")
+	rootCmd.PersistentFlags().StringVar(&websocketServer, "websocket-server", api.DefaultWebSocketBase, "WebSocket Server URL")
 }

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -18,6 +18,7 @@ var tuiCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Token is already loaded by rootCmd.PersistentPreRun
 		client := api.NewClient(apiServer, token)
+		client.WebSocketBase = websocketServer
 		m := ui.NewModel(client)
 
 		p := tea.NewProgram(m, tea.WithAltScreen())

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Current version of the CLI. This should be updated when bumping versions
-const CurrentVersion = "1.0.6"
+const CurrentVersion = "1.0.7"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SHIP CLI Documentation
 
-The `ship-cli` is a powerful, interactive command-line tool built with Go. It allows developers to seamlessly interact with the SHIP Platform directly from their terminal, providing features like listing projects, viewing applications, and establishing secure port-forwarding tunnels to internal Kubernetes pods.
+The `ship-cli` is a powerful, interactive command-line tool built with Go. It allows developers to seamlessly interact with the SHIP Platform directly from their terminal, providing features like listing projects, viewing applications, and establishing secure port-forwarding tunnels to internal application services.
 
 ## Table of Contents
 1. [Features](#features)
@@ -41,7 +41,7 @@ To launch the interactive Text User Interface (TUI):
 
 To run a port-forward directly without the TUI:
 ```bash
-./ship port-forward <APP_ID> --local-port 5432 --target-port 5432
+./ship port-forward <APP_ID> --local-port 5432
 ```
 
 ---
@@ -67,7 +67,7 @@ A standard HTTP client that communicates with `https://api.ship-platform.com`. I
 
 ### 3. User Interface (`ui/`)
 Built using `charmbracelet/bubbletea` (The Elm architecture for Go). It operates on a state machine:
-`InputToken -> LoadProjects -> SelectProject -> LoadApps -> SelectApp -> SelectAction -> InputPorts -> PortForwarding`
+`InputToken -> LoadProjects -> SelectProject -> LoadApps -> SelectApp -> SelectAction -> InputLocalPort -> PortForwarding`
 
 ### 4. Configuration (`config/`)
 Handles securely storing the user's PAT in `~/.ship/config.json` so subsequent runs do not require re-authentication.
@@ -87,16 +87,19 @@ The CLI authenticates with the SHIP Platform using **Personal Access Tokens (PAT
 
 ## Port Forwarding Deep Dive
 
-The most complex feature of the CLI is the Port Forwarding mechanism. It allows a user to securely connect to an internal, non-public pod (like a PostgreSQL database) from their local machine.
+The Port Forwarding mechanism allows a user to securely connect to an
+internal, non-public application service from their local machine. The user
+selects only the local port; SHIP routes to the runtime port declared by the
+application.
 
 ### The Flow
 1. **Local Listener**: The CLI starts a local TCP server (e.g., `localhost:5432`).
-2. **WebSocket Upgrade**: The CLI initiates a WebSocket connection to `wss://console.ship-platform.com/ws/portforward/<APP_ID>?port=<TARGET_PORT>&token=<PAT>`.
+2. **WebSocket Upgrade**: The CLI initiates a WebSocket connection to `wss://console.ship-platform.com/ws/portforward/<APP_ID>?token=<PAT>`. Use `--websocket-server` to select a local or self-hosted WebSocket edge independently from the REST `--server` value.
 3. **Backend Proxy**: The `ship-api` backend verifies the token, ensures the user owns the application, and dials the internal Kubernetes Service via raw TCP.
 4. **Binary Streaming**: 
    - When a local client (like `psql`) connects to the CLI, the CLI reads the raw TCP bytes.
    - It wraps these bytes in `websocket.BinaryMessage` frames and sends them to the backend.
-   - The backend unwraps the frames and writes the raw bytes to the internal database pod.
+   - The backend unwraps the frames and writes the raw bytes to the application service.
    - The reverse happens for responses from the database.
 
 ### Why WebSockets?

--- a/ui/tui.go
+++ b/ui/tui.go
@@ -30,16 +30,16 @@ var (
 	colorGray      = lipgloss.Color("#4B5563") // Gray for inactive/borders
 
 	docStyle = lipgloss.NewStyle().Margin(1, 2)
-	
-	titleStyle = lipgloss.NewStyle().
-		Foreground(colorAccent).
-		Background(colorPrimary).
-		Bold(true).
-		Padding(0, 1).
-		MarginBottom(1)
 
-	statusStyle = lipgloss.NewStyle().Foreground(colorGray)
-	errorStyle  = lipgloss.NewStyle().Foreground(colorSecondary).Bold(true)
+	titleStyle = lipgloss.NewStyle().
+			Foreground(colorAccent).
+			Background(colorPrimary).
+			Bold(true).
+			Padding(0, 1).
+			MarginBottom(1)
+
+	statusStyle  = lipgloss.NewStyle().Foreground(colorGray)
+	errorStyle   = lipgloss.NewStyle().Foreground(colorSecondary).Bold(true)
 	successStyle = lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
 
 	// Custom list styles
@@ -66,7 +66,6 @@ const (
 	stateSelectApp
 	stateSelectAction
 	stateInputLocalPort
-	stateInputTargetPort
 	stateViewPortForward
 	stateViewLogs
 	stateError
@@ -83,32 +82,30 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type PortForwardSession struct {
-	AppID      string
-	AppName    string
-	LocalPort  int
-	TargetPort int
-	Listener   net.Listener
-	Cancel     context.CancelFunc
+	AppID     string
+	AppName   string
+	LocalPort int
+	Listener  net.Listener
+	Cancel    context.CancelFunc
 }
 
 type Model struct {
-	state       state
-	client      *api.Client
-	list        list.Model
-	textInput   textinput.Model
-	
-	projects    []api.Project
-	apps        []api.Application
-	
+	state     state
+	client    *api.Client
+	list      list.Model
+	textInput textinput.Model
+
+	projects []api.Project
+	apps     []api.Application
+
 	selectedProject api.Project
 	selectedApp     api.Application
-	
-	localPort   int
-	targetPort  int
-	
-	err         error
-	statusMsg   string
-	
+
+	localPort int
+
+	err       error
+	statusMsg string
+
 	activeForwards map[string]*PortForwardSession
 	logLines       []string
 	logCancel      context.CancelFunc
@@ -121,7 +118,7 @@ func NewModel(client *api.Client) Model {
 	ti.PromptStyle = lipgloss.NewStyle().Foreground(colorPrimary)
 	ti.TextStyle = lipgloss.NewStyle().Foreground(colorText)
 	ti.Cursor.Style = lipgloss.NewStyle().Foreground(colorSecondary)
-	
+
 	initialState := stateLoadingProjects
 	if client.Token == "" {
 		initialState = stateInputToken
@@ -146,7 +143,7 @@ func NewModel(client *api.Client) Model {
 	l.Styles.Title = titleStyle
 	l.Styles.FilterPrompt = lipgloss.NewStyle().Foreground(colorPrimary)
 	l.Styles.FilterCursor = lipgloss.NewStyle().Foreground(colorSecondary)
-	
+
 	l.AdditionalShortHelpKeys = func() []key.Binding {
 		return []key.Binding{logoutBinding}
 	}
@@ -179,7 +176,7 @@ func waitForLogLine(c chan string) tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if key.Matches(msg, logoutBinding) && m.state != stateInputToken && m.state != stateInputLocalPort && m.state != stateInputTargetPort {
+		if key.Matches(msg, logoutBinding) && m.state != stateInputToken && m.state != stateInputLocalPort {
 			for _, session := range m.activeForwards {
 				session.Cancel()
 				session.Listener.Close()
@@ -216,7 +213,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Quit
 		}
-		
+
 		if msg.String() == "esc" || msg.String() == "q" {
 			if m.state == stateSelectProject || m.state == stateError || m.state == stateInputToken {
 				for _, session := range m.activeForwards {
@@ -226,7 +223,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.logCancel != nil {
 					m.logCancel()
 				}
-				
+
 				// Add specific fallback for unauthorized errors to allow token re-entry
 				if m.state == stateError && strings.Contains(m.err.Error(), "401") {
 					cfg, err := config.LoadConfig()
@@ -245,7 +242,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.textInput.Focus()
 					return m, textinput.Blink
 				}
-				
+
 				return m, tea.Quit
 			}
 			if m.state == stateViewLogs {
@@ -276,7 +273,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.list.SetItems(appsToItems(m.apps, m.activeForwards))
 				return m, nil
 			}
-			if m.state == stateInputLocalPort || m.state == stateInputTargetPort {
+			if m.state == stateInputLocalPort {
 				m.state = stateSelectAction
 				m.list.Title = "Select Action"
 				m.list.SetItems(actionItems(m.selectedApp.ID, m.activeForwards))
@@ -324,7 +321,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list.Title = fmt.Sprintf("Applications in %s", m.selectedProject.Name)
 		m.list.SetItems(appsToItems(m.apps, m.activeForwards))
 		return m, nil
-		
+
 	case portForwardStartedMsg:
 		m.activeForwards[msg.session.AppID] = msg.session
 		m.statusMsg = fmt.Sprintf("Started forwarding %s to localhost:%d", msg.session.AppName, msg.session.LocalPort)
@@ -343,7 +340,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			token := strings.TrimSpace(m.textInput.Value())
 			if token != "" {
 				m.client.Token = token
-				
+
 				cfg, err := config.LoadConfig()
 				if err == nil {
 					cfg.Token = token
@@ -412,7 +409,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					ctx, cancel := context.WithCancel(context.Background())
 					m.logCancel = cancel
 					m.logChan = make(chan string)
-					
+
 					startLogsStream(ctx, m.client, m.selectedApp.ID, m.logChan)
 					return m, waitForLogLine(m.logChan)
 				}
@@ -426,22 +423,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			port, err := strconv.Atoi(m.textInput.Value())
 			if err == nil && port > 0 && port < 65536 {
 				m.localPort = port
-				m.state = stateInputTargetPort
-				m.textInput.Placeholder = "e.g. 80 or 5432"
-				m.textInput.SetValue("")
-				m.textInput.Focus()
-			}
-		}
-		return m, cmd
-
-	case stateInputTargetPort:
-		m.textInput, cmd = m.textInput.Update(msg)
-		if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "enter" {
-			port, err := strconv.Atoi(m.textInput.Value())
-			if err == nil && port > 0 && port < 65536 {
-				m.targetPort = port
 				ctx, cancel := context.WithCancel(context.Background())
-				return m, startPortForward(ctx, cancel, m.client, m.selectedApp, m.localPort, m.targetPort)
+				return m, startPortForward(ctx, cancel, m.client, m.selectedApp, m.localPort)
 			}
 		}
 		return m, cmd
@@ -459,9 +442,9 @@ func (m Model) View() string {
 	case stateInputToken:
 		return docStyle.Render(
 			titleStyle.Render("Authentication") + "\n\n" +
-			"Please enter your Personal Access Token (PAT):\n" +
-			m.textInput.View() + "\n\n" +
-			statusStyle.Render("(esc to quit)"),
+				"Please enter your Personal Access Token (PAT):\n" +
+				m.textInput.View() + "\n\n" +
+				statusStyle.Render("(esc to quit)"),
 		)
 	case stateLoadingProjects:
 		return docStyle.Render("Loading projects...")
@@ -480,19 +463,10 @@ func (m Model) View() string {
 	case stateInputLocalPort:
 		return docStyle.Render(
 			titleStyle.Render("Port Forwarding") + "\n\n" +
-			fmt.Sprintf("App: %s\n\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(m.selectedApp.Name)) +
-			"Enter Local Port:\n" +
-			m.textInput.View() + "\n\n" +
-			statusStyle.Render("(esc to go back)"),
-		)
-	case stateInputTargetPort:
-		return docStyle.Render(
-			titleStyle.Render("Port Forwarding") + "\n\n" +
-			fmt.Sprintf("App: %s\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(m.selectedApp.Name)) +
-			fmt.Sprintf("Local Port: %s\n\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(strconv.Itoa(m.localPort))) +
-			"Enter Target Port (Pod Port):\n" +
-			m.textInput.View() + "\n\n" +
-			statusStyle.Render("(esc to go back)"),
+				fmt.Sprintf("App: %s\n\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(m.selectedApp.Name)) +
+				"Enter Local Port:\n" +
+				m.textInput.View() + "\n\n" +
+				statusStyle.Render("(esc to go back)"),
 		)
 	case stateViewPortForward:
 		session := m.activeForwards[m.selectedApp.ID]
@@ -501,21 +475,21 @@ func (m Model) View() string {
 		}
 		return docStyle.Render(
 			titleStyle.Render("Port Forward Details") + "\n\n" +
-			fmt.Sprintf("App: %s\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(session.AppName)) +
-			fmt.Sprintf("Status: %s\n", successStyle.Render("Active ⚡")) +
-			fmt.Sprintf("Forwarding: %s -> %s\n\n", 
-				lipgloss.NewStyle().Foreground(colorPrimary).Render(fmt.Sprintf("127.0.0.1:%d", session.LocalPort)),
-				lipgloss.NewStyle().Foreground(colorSecondary).Render(fmt.Sprintf("pod:%d", session.TargetPort)),
-			) +
-			"You can connect to this application using the local port above.\n\n" +
-			statusStyle.Render("Press 'esc' to go back."),
+				fmt.Sprintf("App: %s\n", lipgloss.NewStyle().Foreground(colorPrimary).Render(session.AppName)) +
+				fmt.Sprintf("Status: %s\n", successStyle.Render("Active ⚡")) +
+				fmt.Sprintf("Forwarding: %s -> %s\n\n",
+					lipgloss.NewStyle().Foreground(colorPrimary).Render(fmt.Sprintf("127.0.0.1:%d", session.LocalPort)),
+					lipgloss.NewStyle().Foreground(colorSecondary).Render("application service"),
+				) +
+				"You can connect to this application using the local port above.\n\n" +
+				statusStyle.Render("Press 'esc' to go back."),
 		)
 	case stateViewLogs:
 		logsView := strings.Join(m.logLines, "")
 		return docStyle.Render(
 			titleStyle.Render(fmt.Sprintf("Logs: %s", m.selectedApp.Name)) + "\n\n" +
-			logsView + "\n\n" +
-			statusStyle.Render("(esc to stop watching and go back)"),
+				logsView + "\n\n" +
+				statusStyle.Render("(esc to stop watching and go back)"),
 		)
 	}
 
@@ -531,7 +505,7 @@ type portForwardErrMsg struct{ err error }
 type newLogLineMsg struct {
 	line string
 }
-type portForwardStartedMsg struct{ 
+type portForwardStartedMsg struct {
 	session *PortForwardSession
 }
 
@@ -570,7 +544,7 @@ func startLogsStream(ctx context.Context, client *api.Client, appID string, logC
 					}
 					return
 				}
-				
+
 				// Parse SSE format (data: ...)
 				if strings.HasPrefix(line, "data: ") {
 					content := strings.TrimPrefix(line, "data: ")
@@ -619,12 +593,12 @@ func appsToItems(apps []api.Application, activeForwards map[string]*PortForwardS
 	for i, a := range apps {
 		title := a.Name
 		desc := fmt.Sprintf("Status: %s | Type: %s", a.Status, a.Type)
-		
+
 		if session, ok := activeForwards[a.ID]; ok {
 			title = fmt.Sprintf("⚡ %s", title)
-			desc = fmt.Sprintf("%s | Fwd: :%d->:%d", desc, session.LocalPort, session.TargetPort)
+			desc = fmt.Sprintf("%s | Fwd: localhost:%d", desc, session.LocalPort)
 		}
-		
+
 		items[i] = item{title: title, desc: desc, id: a.ID, data: a}
 	}
 	return items
@@ -633,28 +607,34 @@ func appsToItems(apps []api.Application, activeForwards map[string]*PortForwardS
 func actionItems(appID string, activeForwards map[string]*PortForwardSession) []list.Item {
 	items := []list.Item{}
 	if _, exists := activeForwards[appID]; exists {
-		items = append(items, 
+		items = append(items,
 			item{title: "View Details", desc: "View port-forward connection details", id: "view-pf"},
 			item{title: "Stop Port Forward", desc: "Close the active port-forward tunnel", id: "stop-pf"},
 		)
 	} else {
-		items = append(items, 
-			item{title: "Start Port Forward", desc: "Forward local port to pod", id: "start-pf"},
+		items = append(items,
+			item{title: "Start Port Forward", desc: "Forward a local port to the application service", id: "start-pf"},
 		)
 	}
 	items = append(items, item{title: "View Logs", desc: "Stream live container logs", id: "view-logs"})
 	return items
 }
 
-func startPortForward(ctx context.Context, cancel context.CancelFunc, client *api.Client, app api.Application, localPort, targetPort int) tea.Cmd {
+func startPortForward(ctx context.Context, cancel context.CancelFunc, client *api.Client, app api.Application, localPort int) tea.Cmd {
 	return func() tea.Msg {
+		wsURL, err := api.BuildPortForwardURL(client.WebSocketBase, app.ID, client.Token)
+		if err != nil {
+			cancel()
+			return portForwardErrMsg{fmt.Errorf("invalid WebSocket server URL: %v", err)}
+		}
+
 		listenAddr := fmt.Sprintf("localhost:%d", localPort)
 		l, err := net.Listen("tcp", listenAddr)
 		if err != nil {
 			cancel()
 			return portForwardErrMsg{fmt.Errorf("failed to listen on %d: %v", localPort, err)}
 		}
-		
+
 		go func() {
 			<-ctx.Done()
 			l.Close()
@@ -666,28 +646,24 @@ func startPortForward(ctx context.Context, cancel context.CancelFunc, client *ap
 				if err != nil {
 					return // closed
 				}
-				go handleConnection(conn, client, app.ID, targetPort)
+				go handleConnection(conn, wsURL)
 			}
 		}()
 
 		session := &PortForwardSession{
-			AppID:      app.ID,
-			AppName:    app.Name,
-			LocalPort:  localPort,
-			TargetPort: targetPort,
-			Listener:   l,
-			Cancel:     cancel,
+			AppID:     app.ID,
+			AppName:   app.Name,
+			LocalPort: localPort,
+			Listener:  l,
+			Cancel:    cancel,
 		}
 
 		return portForwardStartedMsg{session: session}
 	}
 }
 
-func handleConnection(localConn net.Conn, client *api.Client, appID string, targetPort int) {
+func handleConnection(localConn net.Conn, wsURL string) {
 	defer localConn.Close()
-
-	wsBase := "wss://console.ship-platform.com"
-	wsURL := fmt.Sprintf("%s/ws/portforward/%s?port=%d&token=%s", wsBase, appID, targetPort, client.Token)
 
 	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {

--- a/ui/tui_test.go
+++ b/ui/tui_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ship-cli/api"
+)
+
+func TestStartPortForwardRejectsInvalidWebSocketBaseBeforeListening(t *testing.T) {
+	client := api.NewClient("https://api.ship-platform.com", "token")
+	client.WebSocketBase = "https://console.ship-platform.com"
+	ctx, cancel := context.WithCancel(context.Background())
+
+	msg := startPortForward(ctx, cancel, client, api.Application{ID: "app-123", Name: "demo"}, 0)()
+	errMsg, ok := msg.(portForwardErrMsg)
+	if !ok {
+		t.Fatalf("message = %T, want portForwardErrMsg", msg)
+	}
+	if !strings.Contains(errMsg.err.Error(), "must use ws or wss") {
+		t.Fatalf("error = %q, want scheme validation", errMsg.err)
+	}
+}
+
+func TestPortForwardLabelsDescribeApplicationService(t *testing.T) {
+	items := actionItems("app-123", map[string]*PortForwardSession{})
+	if len(items) == 0 || !strings.Contains(items[0].(item).desc, "application service") {
+		t.Fatalf("start action = %#v, want application service label", items)
+	}
+}


### PR DESCRIPTION
## Summary
- remove target-port selection from the direct command and TUI
- add an independent configurable WebSocket server base
- safely encode application IDs and PAT query values
- prepare CLI v1.0.7 and update user documentation

## Verification
- go test ./...
- go test -race ./...
- go vet ./...
- go run . port-forward --help

## Rollout
Merge this PR and publish v1.0.7 before the ship-platform P0-004 API change is deployed. The release gives users the local-port-only client before old default target-port values are rejected.